### PR TITLE
Update formatting and defaults

### DIFF
--- a/doc/attribmapping-basics/faws-mapping.rst
+++ b/doc/attribmapping-basics/faws-mapping.rst
@@ -17,22 +17,20 @@ applied to your AWS account permissions.
 The following example shows a basic policy with the required rule included:
 
 .. code:: yaml
-
     mapping:
-     version: RAX-1
-     rules:
-     - local:
-        user:
-           domain: '99199991999'
-           email: "{At(urn:oid:1.2.840.113549.1.9.1.1)}"
-           expire: "{Pt(/saml2p:Response/saml2:Assertion/saml2:Conditions/@NotOnOrAfter[1])}"
-           name: "{D}"
-           roles:
-            - "nova:admin"
-        faws:
-           groups:
-               multiValue: true
-               value: "{Ats(http://schemas.xmlsoap.org/claims/Group)}"
+      rules:
+        -
+          local:
+            user:
+              domain: "{D}"
+              email: "{Pt(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID)    }"
+              expire: "{D}"
+              name: "{D}"
+            faws:
+              groups:
+                multiValue: true
+                value: "{Ats(http://schemas.xmlsoap.org/claims/Group)}"
+      version: RAX-1
 
 The lines below ``faws`` indicate that any value associated with the SAML
 schema attribute ``http://schemas.xmlsoap.org/claims/Group`` will be assigned

--- a/doc/attribmapping-basics/faws-mapping.rst
+++ b/doc/attribmapping-basics/faws-mapping.rst
@@ -23,7 +23,7 @@ The following example shows a basic policy with the required rule included:
           local:
             user:
               domain: "{D}"
-              email: "{Pt(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID)    }"
+              email: "{Pt(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID)}"
               expire: "{D}"
               name: "{D}"
             faws:


### PR DESCRIPTION
I'd like to switch out all our documentation to start using more default values, this will make it less error prone for customers who might fat finger wrong values into their policies.