### PR TITLE
Tenant roles section for faws

### DIFF
--- a/doc/attribmapping-basics/faws-mapping.rst
+++ b/doc/attribmapping-basics/faws-mapping.rst
@@ -16,7 +16,8 @@ applied to your AWS account permissions.
 
 The following example shows a basic policy with the required rule included:
 
-.. code:: yaml
+.. code-block:: yaml
+
     mapping:
       rules:
         -

--- a/doc/attribmapping-basics/faws-mapping.rst
+++ b/doc/attribmapping-basics/faws-mapping.rst
@@ -10,11 +10,11 @@ accounts managed by **Fanatical Support for AWS**.
 Update Attribute Mapping Policy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, you need to ensure that you have added a rule section to your
+First, you need to ensure that you have added a ``rules`` section to your
 |amp| that indicates that any ``groups`` provided in your SAML response will be
 applied to your AWS account permissions.
 
-The following example shows a basic policy with the required rule included:
+The following example shows a basic policy with the required rules included:
 
 .. code-block:: yaml
 
@@ -36,6 +36,45 @@ The following example shows a basic policy with the required rule included:
 The lines below ``faws`` indicate that any value associated with the SAML
 schema attribute ``http://schemas.xmlsoap.org/claims/Group`` will be assigned
 to the ``faws/groups`` local value.
+
+.. note::
+    If you use a different SAML attribute to provide a ``groups`` value, or
+    something similar, substitute that attribute instead.
+
+
+Cloud Tenant Role Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows a basic policy with cloud tenant roles to configure rackspace identity permissions for specific AWS accounts:
+
+
+.. code-block:: yaml
+
+
+    mapping:
+      rules:
+        -
+          local:
+            faws:
+              groups:
+                multiValue: true
+                value:
+                  - "{Ats(groups)}"
+            user:
+              domain: "{D}"
+              email: "{Pt(/saml2p:Response/saml2:Assertion/saml2:Subject/saml2:NameID)}"
+              expire: "PT12H"
+              name: "{D}"
+              roles:
+                - "{0}"
+          remote:
+            -
+              multiValue: true
+              path: |
+                  (
+                    if (mapping:get-attributes('groups')='your_sso_ldap_group') then ('role_name/insert_tenant_id_here')     else ()
+                  )
+      version: RAX-1
 
 .. note::
     If you use a different SAML attribute to provide a ``groups`` value, or


### PR DESCRIPTION
Reviewers can help answer the following questions:

- should we be referring to multiple aws accounts as aws `cloud tenants` on an account? @rtgoodwin is there a more specific product term we should be referring to these aws accounts as besides just `tenants`?
- is the language clear? are there any other links we should be sending users to for some of the terminology? which docs would you recommend we link to and where inside this document should we link them?
- is the example too generic or should we focus it on something specific like ticketing?
- should we remove the section about contacting support for setting up federation with faws since rackspace currently only supports it for select beta customers https://github.com/rackerlabs/docs-rackspace-federation/pull/44/files#diff-ccf19521e9bb5d5ab76333c1b243ca60R84