### PR TITLE
Fix link text

### DIFF
--- a/doc/config-3p-saml/generic-3p-saml.rst
+++ b/doc/config-3p-saml/generic-3p-saml.rst
@@ -18,7 +18,7 @@ The metadata file contains the latest certificate for signing SAML assertions.
 
 The default values can be retrieved programmatically from the Rackspace service
 provider metadata file at `https://login.rackspace.com/federate/sp.xml
-<https:login.rackspace.com/federate/sp.xml>`_ and are shown in the following
+<https://login.rackspace.com/federate/sp.xml>`_ and are shown in the following
 list:
 
 .. list-table::

--- a/doc/gettingstarted/add-idp-cp.rst
+++ b/doc/gettingstarted/add-idp-cp.rst
@@ -5,7 +5,7 @@ Add an Identity Provider in the Control Panel
 =============================================
 
 To add an |idp|, log in to the Rackspace Control Panel by browsing to
-https://login.rackspace.com.
+`https://login.rackspace.com <https://login.rackspace.com>`_.
 
 1. In the upper right area of the navigation bar select **Account** then
    **User Management** from the dropdown menu. Alternately, browse

--- a/doc/gettingstarted/add-idp-cp.rst
+++ b/doc/gettingstarted/add-idp-cp.rst
@@ -5,7 +5,7 @@ Add an Identity Provider in the Control Panel
 =============================================
 
 To add an |idp|, log in to the Rackspace Control Panel by browsing to
-`https://login.rackspace.com <https://login.rackspace.com>`_.
+https://login.rackspace.com.
 
 1. In the upper right area of the navigation bar select **Account** then
    **User Management** from the dropdown menu. Alternately, browse

--- a/doc/gettingstarted/add-idp-cp.rst
+++ b/doc/gettingstarted/add-idp-cp.rst
@@ -6,14 +6,14 @@ Add an Identity Provider in the Control Panel
 
 Use the following steps to add an |idp|:
 
-1. Log in to the `MyRackspace Portal <https://login.rackspace.com>`_.
+1. Log in to the `Rackspace Portal <https://login.rackspace.com>`_.
 
 2. In the upper right area of the navigation bar, select
    **Account > User Management** from the drop-down menu. Alternately, browse
    directly to the `User Management <https://account.rackspace.com/users>`_
    page in the Rackspace Account Management Control Panel.
 
-3. In the subnavigation bar, select **Federation**.
+3. In the subnavigation bar, select **Identity Federation**.
 
 4. Click **Add Identity Provider**.
 

--- a/doc/gettingstarted/add-idp-cp.rst
+++ b/doc/gettingstarted/add-idp-cp.rst
@@ -6,7 +6,7 @@ Add an Identity Provider in the Control Panel
 
 Use the following steps to add an |idp|:
 
-1. Log in to the `Rackspace Portal <https://login.rackspace.com>`_.
+1. Log in to the `Rackspace Customer Portal <https://login.rackspace.com>`_.
 
 2. In the upper right area of the navigation bar, select
    **Account > User Management** from the drop-down menu. Alternately, browse


### PR DESCRIPTION
~~The build is auto de-referencing login.rackspace.com to "MyRackspace"~~
I'm a goof and hadn't pulled in new `master`. Done and updated PR. 