### PR TITLE
Improve clarity about how permissions are granted

### DIFF
--- a/doc/config-attribute-mapping/faws-mapping.rst
+++ b/doc/config-attribute-mapping/faws-mapping.rst
@@ -192,10 +192,9 @@ policy below assigns permissions as follows:
 
 In the above example, a user who is a member of both the
 ``mycompany.global.security`` group and the ``mycompany.123456789012.admin``
-group, would be granted ``AdministratorAccess`` IAM policy for AWS account
-``123456789012``. This is because the full set of permissions granted to the
-user is the union of the permissions granted by each of the ``iamPolicies``
-in the ``aws`` section of the mapping YAML file.
+group, both the ``AdministratorAccess`` IAM policy and the ``SecurityAudit``
+IAM policy would be attached to the user's temporary session for AWS account
+``123456789012``. 
 
 Customer-managed AWS IAM Policies that are the same across AWS accounts
 -----------------------------------------------------------------------

--- a/doc/config-attribute-mapping/faws-mapping.rst
+++ b/doc/config-attribute-mapping/faws-mapping.rst
@@ -4,12 +4,12 @@
 Assigning Fanatical Support for AWS Permissions
 ===============================================
 
-Fanatical Support for AWS Permissions
+Fanatical support for AWS permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These permissions control access to features within Rackspace's Fanatical
-Support for Amazon Web Services (FAWS) Control Panel. You can assign the roles 
-of ``observer``, ``admin``, or omit them from the mapping policy. Users with 
+Support for the Amazon Web Services (FAWS) Control Panel. You can assign the roles 
+of ``observer`` or ``admin`` or omit them from the mapping policy. Users with 
 ``observer`` permissions have read-only access to the Control Panel. Users with
  ``admin`` permissions have read and write access to the Control Panel. The 
 following mapping policy assigns the ``admin`` role to all federated users:
@@ -29,10 +29,9 @@ following mapping policy assigns the ``admin`` role to all federated users:
               - "admin"
 
 It's common to assign roles based on a user's group membership. 
-In the following mapping policy example, users who belong to the
-``mycompany.global.admin`` group are granted the ``admin`` role, and users who
-belong to the ``mycompany.global.observer`` group are granted the ``observer``
-role:
+The following mapping policy example grants the ``admin`` role to users who
+belong to the ``mycompany.global.admin`` group, and the ``observer``
+role to users who belong to the ``mycompany.global.observer`` group:
 
 .. code:: yaml
 
@@ -56,10 +55,10 @@ role:
             multiValue: true
 
 You can limit the roles of ``admin`` and ``observer`` to specific Amazon Web 
-Services® (AWS) accounts. In the preceding policy example, members of the 
-``mycompany.scoped.admin`` group are granted the FAWS ``admin`` role on multiple
- AWS accounts, and members of ``mycompany.scoped.observer`` are granted 
- ``observer`` on the single account ``12345678012`` :
+Services® (AWS) accounts. The preceding policy example grants the FAWS ``admin`` role
+to members of the ``mycompany.scoped.admin`` group on multiple
+ AWS accounts, and the  ``observer`` role to members of ``mycompany.scoped.observer``
+ on the single account ``12345678012``:
 
 .. code:: yaml
 
@@ -90,10 +89,10 @@ In the preceding example, members of both the ``mycompany.scoped.admin`` group
 and the ``mycompany.scoped.observer`` group have the ``admin`` role on the 
 single FAWS account ``12345678012``. 
 
-Swapping the ``admin`` and ``observer`` groups in the next example, grants 
+Swapping the ``admin`` and ``observer`` groups in the next example grants 
 only the ``observer`` role on that single account to any
-user in both groups . This is because the first ``if`` condition matches, so the
-policy doesn't evaluate the second ``if`` condition. 
+user in both groups. This assignment occurs because the first ``if`` condition
+matches, so the policy doesn't evaluate the second ``if`` condition. 
 
 .. code:: yaml
 
@@ -123,7 +122,7 @@ policy doesn't evaluate the second ``if`` condition.
 Visit the `User Management and Permissions <https://manage.rackspace.com/aws/docs/product-guide/access_and_permissions/user_management_and_permissions.html>`_
 section of the Fanatical Support for AWS product guide for further details.
 
-AWS Console and API Permissions
+AWS console and API permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These permissions control access to the Amazon Web Services APIs and to
@@ -194,18 +193,18 @@ groups, have the``AdministratorAccess`` IAM policy. In this case, the
 ``SecurityAudit`` IAM policy attaches to the user's temporary session for the 
 AWS account ``123456789012``. 
 
-Customer-managed AWS IAM Policies that are the same across AWS accounts
+Customer-managed AWS IAM policies that are the same across AWS accounts
 -----------------------------------------------------------------------
 
 Many customers create their own
-`customer managed policies <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies>`_
+`customer-managed policies <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#customer-managed-policies>`_
 that are the same across many AWS accounts. Policy ARNs can omit the account ID
 section, which makes it easier to assign these policies. For example, if a
 policy named ``MyCompany.Audit`` exists on every AWS account, you can assign
 this policy by using ``arn:aws:iam:::policy/MyCompany.Audit`` in your mapping
 policy.
 
-AWS Account Creator Permissions
+AWS account creator permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This permission controls whether a user can create new AWS accounts
@@ -233,7 +232,7 @@ create new AWS accounts:
               )
             multiValue: false
 
-Complete Mapping Policy Example
+Complete mapping policy example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example combines both Fanatical Support for AWS permissions and

--- a/doc/config-attribute-mapping/faws-mapping.rst
+++ b/doc/config-attribute-mapping/faws-mapping.rst
@@ -8,12 +8,11 @@ Fanatical Support for AWS Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These permissions control access to features within Rackspace's Fanatical
-Support for AWS Control Panel. User permissions can be set to ``observer``,
-``admin``, or omitted from the mapping policy. Users with ``observer``
-permissions have read-only access to the Control Panel. Users with ``admin``
-permissions have read and write access to the Control Panel. These permissions
-are assigned by granting them as roles in a mapping policy. The following
-mapping policy assigns the ``admin`` role to all federated users:
+Support for Amazon Web Services (FAWS) Control Panel. You can assign the roles 
+of ``observer``, ``admin``, or omit them from the mapping policy. Users with 
+``observer`` permissions have read-only access to the Control Panel. Users with
+ ``admin`` permissions have read and write access to the Control Panel. The 
+following mapping policy assigns the ``admin`` role to all federated users:
 
 .. code:: yaml
 
@@ -29,8 +28,8 @@ mapping policy assigns the ``admin`` role to all federated users:
             roles:
               - "admin"
 
-It's much more common to assign roles conditionally based on a user's group
-membership. In the following mapping policy, users who belong to the
+It's common to assign roles based on a user's group membership. 
+In the following mapping policy example, users who belong to the
 ``mycompany.global.admin`` group are granted the ``admin`` role, and users who
 belong to the ``mycompany.global.observer`` group are granted the ``observer``
 role:
@@ -56,11 +55,11 @@ role:
               )
             multiValue: true
 
-``admin`` and ``observer`` can also be scoped to specific AWS accounts. In this
-policy, members of the ``mycompany.scoped.admin`` group are granted the FAWS
-``admin`` role on multiple AWS accounts, and members of
-``mycompany.scoped.observer`` are granted ``observer`` on the single account
-``12345678012`` :
+You can limit the roles of ``admin`` and ``observer`` to specific Amazon Web 
+Services® (AWS) accounts. In the preceding policy example, members of the 
+``mycompany.scoped.admin`` group are granted the FAWS ``admin`` role on multiple
+ AWS accounts, and members of ``mycompany.scoped.observer`` are granted 
+ ``observer`` on the single account ``12345678012`` :
 
 .. code:: yaml
 
@@ -87,14 +86,14 @@ policy, members of the ``mycompany.scoped.admin`` group are granted the FAWS
               )
             multiValue: true
 
-In the above example, a user who is a member of both the
-``mycompany.scoped.admin`` group and the ``mycompany.scoped.observer`` group,
-would be granted the FAWS ``admin`` role on the single account ``12345678012``.
+In the preceding example, members of both the ``mycompany.scoped.admin`` group 
+and the ``mycompany.scoped.observer`` group have the ``admin`` role on the 
+single FAWS account ``12345678012``. 
 
-However, if the mapping order for the admin and observer groups were swapped as
-in the next example, then a user in both of those groups would be granted just
-the ``observer`` role on that single account. This is because the first ``if``
-condition matches, so the second ``if`` condition is not evaluated.
+Swapping the ``admin`` and ``observer`` groups in the next example, grants 
+only the ``observer`` role on that single account to any
+user in both groups . This is because the first ``if`` condition matches, so the
+policy doesn't evaluate the second ``if`` condition. 
 
 .. code:: yaml
 
@@ -121,9 +120,8 @@ condition matches, so the second ``if`` condition is not evaluated.
               )
             multiValue: true
 
-For more information about Fanatical Support for AWS permissions, visit the
-`User Management and Permissions <https://manage.rackspace.com/aws/docs/product-guide/access_and_permissions/user_management_and_permissions.html>`_
-section of the Fanatical Support for AWS product guide.
+Visit the `User Management and Permissions <https://manage.rackspace.com/aws/docs/product-guide/access_and_permissions/user_management_and_permissions.html>`_
+section of the Fanatical Support for AWS product guide for further details.
 
 AWS Console and API Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -152,7 +150,7 @@ users the "ViewOnlyAccess" IAM policy for all AWS accounts. It also assigns the
 
 As with Fanatical Support for AWS permissions, it's much more common to assign
 IAM policies conditionally based on a user's group membership. The mapping
-policy below assigns permissions as follows:
+policy assigns permissions as follows:
 
 * Users in the ``mycompany.global.security`` group are assigned the
   ``SecurityAudit`` IAM policy on all AWS accounts.
@@ -190,11 +188,11 @@ policy below assigns permissions as follows:
               )
             multiValue: true
 
-In the above example, a user who is a member of both the
-``mycompany.global.security`` group and the ``mycompany.123456789012.admin``
-group, both the ``AdministratorAccess`` IAM policy and the ``SecurityAudit``
-IAM policy would be attached to the user's temporary session for AWS account
-``123456789012``. 
+In the preceding example, members of the
+``mycompany.global.security`` and the ``mycompany.123456789012.admin``
+groups, have the``AdministratorAccess`` IAM policy. In this case, the 
+``SecurityAudit`` IAM policy attaches to the user's temporary session for the 
+AWS account ``123456789012``. 
 
 Customer-managed AWS IAM Policies that are the same across AWS accounts
 -----------------------------------------------------------------------
@@ -210,7 +208,7 @@ policy.
 AWS Account Creator Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This permission controls whether or not a user can create new AWS accounts
+This permission controls whether a user can create new AWS accounts
 through the Fanatical Support for AWS Control Panel. The following mapping
 policy grants users in the ``mycompany.global.admin`` group permission to
 create new AWS accounts:

--- a/doc/config-attribute-mapping/faws-mapping.rst
+++ b/doc/config-attribute-mapping/faws-mapping.rst
@@ -4,12 +4,6 @@
 Assigning Fanatical Support for AWS Permissions
 ===============================================
 
-**Note:** Identity Federation for Fanatical Support for AWS is available as
-part of a **public beta**. It is available to all customers, but phone support
-is not available for federated users. Federated users need to submit all
-support requests through the
-`Rackspace ticketing portal <https://portal.rackspace.com/tickets>`_.
-
 Fanatical Support for AWS Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Improve clarity about how permissions are granted to users in more than one group, and for mapping files with overlapping iamPolicies.